### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Fill in `start_urls.txt` with start pages of Tumblr blogs.
 
 Run:
 ```bash
-scrapy crawl tumblr_spider
+scrapy crawl tumblr-spider
 ```
 
 Images from each blog will be saved into `images/blogname.tumblr.com/`.


### PR DESCRIPTION
name defined in TumblrSpiderSpider uses hyphen not underscore